### PR TITLE
Fixed authors section of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ build-backend = "setuptools.build_meta"
 name = "proxy_vis"
 authors = [{"name" = "Galina Chirokova", "email" = "Galina.Chirokova@colostate.edu"},
            {"name" = "Robert DeMaria", "email" = "Robert.DeMaria@colostate.edu"},
-           {"name" = "Alan Brammer", },
-]
+           {"name" = "Alan Brammer"}]
 description = "ProxyVis algorithms and composite utilities."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.7"


### PR DESCRIPTION
The authors section in pyproject.toml was incorrectly formatted.  This fixes it.