### PR TITLE
Replaced the deprecated np.NaN with np.nan in solar_zenith_angle module.

### DIFF
--- a/proxy_vis/solar_zenith_angle.py
+++ b/proxy_vis/solar_zenith_angle.py
@@ -67,10 +67,10 @@ def sza_to_mask(sza, mask_night=True, sza_thresh=90.0):
     """
 
     if mask_night:
-        sza[sza > sza_thresh] = np.NaN
+        sza[sza > sza_thresh] = np.nan
         sza[sza <= sza_thresh] = 1.0
     else:
-        sza[sza <= sza_thresh] = np.NaN
+        sza[sza <= sza_thresh] = np.nan
         sza[sza > sza_thresh] = 1.0
 
     return sza


### PR DESCRIPTION
np.NaN was deprecated a while ago and no longer works with newer versions of numpy.  This only appeared in the solar zenith angle calculation code.  I replaced np.NaN with np.nan in that module.